### PR TITLE
Avoid script error when there are no Disqus widgets on the page

### DIFF
--- a/disqusloader.js
+++ b/disqusloader.js
@@ -109,7 +109,7 @@
 		else if( typeof element.length === 'number' )	instance = element[ 0 ];
 		else											instance = element;
 
-		instance.disqusLoaderStatus = 'unloaded';
+		if (instance) instance.disqusLoaderStatus = 'unloaded';
 
 		init();
 	};


### PR DESCRIPTION
Hi Osvaldas,

Here's the scenario I'd like to fix with this PR:
1. Some pages of a site contain Disqus comments widget optimized with lazy loading, some pages don't.
2. There is a JavaScript file that got loaded for every page of a site. It contains the vanilla disqusLoader functionality, as well as the initialization for widgets (i.e. disqusLoader('.disqus', disqus_options);). The goal here is that while creating a new page with comments, one should add only html markup. Scripts and initialization logic should be transparent for a page creator.
3. For pages that don't contain Disqus widgets the disqusLoader fails with an error: "Cannot set property 'disqusLoaderStatus' of null".

This error does not occur for the jQuery version.

I've added a check that the instance exists before setting disqusLoaderStatus property to avoid this error.