### PR TITLE
Fix empty scrollTop, simplify distance checking

### DIFF
--- a/disqusloader.js
+++ b/disqusloader.js
@@ -26,7 +26,7 @@
 		getOffset = function( el )
 		{
 			var rect = el.getBoundingClientRect();
-			return { top: rect.top + document.body.scrollTop, left: rect.left + document.body.scrollLeft };
+			return { top: rect.top, bottom: rect.bottom };
 		},
 		loadScript = function( url, callback )
 		{
@@ -56,11 +56,10 @@
 			if( !instance || !document.body.contains( instance ) || instance.disqusLoaderStatus == 'loaded' )
 				return true;
 
-			var winST	= window.pageYOffset,
-				offset	= getOffset( instance ).top;
+			var offset = getOffset( instance );
 
 			// if the element is too far below || too far above
-			if( offset - winST > window.innerHeight * laziness || winST - offset - instance.offsetHeight - ( window.innerHeight * laziness ) > 0 )
+			if( offset.top > window.innerHeight * laziness || offset.bottom < - instance.offsetHeight - ( window.innerHeight * laziness ) )
 				return true;
 
 			var tmp = document.getElementById( 'disqus_thread' );


### PR DESCRIPTION
At line 29, `document.body.scrollTop` returns 0 on Chrome, Firefox etc. It is recommended to use `document.scrollingElement.scrollTop` instead. 
Actually here (at line 63) `getBoundingClientRect()` is enough to get the distance between the Disqus widget and the top of viewport.